### PR TITLE
V0.6.2

### DIFF
--- a/PyHab/PyHabBuilder.py
+++ b/PyHab/PyHabBuilder.py
@@ -32,8 +32,10 @@ class PyHabBuilder:
         self.loadSave = loadedSaved #For easy reference elsewhere
         if os.name is 'posix': #glorious simplicity of unix filesystem
             self.dirMarker = '/'
+            otherOS = '\\'
         elif os.name is 'nt': #Nonsensical Windows-based contrarianism
-            self.dirMarker='\\'
+            self.dirMarker = '\\'
+            otherOS = '/'
         #The base window
         width = 1080
         height = 600
@@ -126,6 +128,11 @@ class PyHabBuilder:
                         'maxOff','minOn','autoAdvance','playAttnGetter','attnGetterList','trialTypes','habTrialList']
             for i in evalList:
                 self.settings[i] = eval(self.settings[i])
+                if i in ['stimList','attnGetterList']:
+                    for [i,j] in self.settings[i].items():
+                        j['stimLoc'] = ''.join([self.dirMarker if x == otherOS else x for x in j['stimLoc']])
+            self.settings['dataloc'] = ''.join([self.dirMarker if x == otherOS else x for x in self.settings['dataloc']])
+            self.settings['stimPath'] = ''.join([self.dirMarker if x == otherOS else x for x in self.settings['stimPath']])
             self.trialTypesArray = self.loadTypes()
             self.studyFlowArray = self.loadFlow()
             # Get conditions!
@@ -1820,11 +1827,11 @@ class PyHabBuilder:
         settingsPath = self.folderPath+self.settings['prefix']+'Settings.csv'
         so = open(settingsPath,'w')
         settingsOutput = csv.writer(so, lineterminator='\n')
-        for i, j in self.settings.items():#this is how you write key/value pairs
+        for i, j in self.settings.items(): # this is how you write key/value pairs
             settingsOutput.writerow([i, j])
         # close the settings file, to allow it to be read immediately (in theory)
         so.close()
-        # Copy over the class and such. Since these aren't modiied, make sure they don't exist first.
+        # Copy over the class and such. Since these aren't modified, make sure they don't exist first.
         classPath = 'PyHabClass.py'
         classTarg = codePath+classPath
         classPLPath = 'PyHabClassPL.py'

--- a/PyHab/PyHabClass.py
+++ b/PyHab/PyHabClass.py
@@ -412,6 +412,7 @@ class PyHab:
                 self.win.flip()
         else:
             dMovie = attnGetter['file']
+            dMovie.seek(0.0)
             self.frameCount = 0
             self.pauseCount = self.ISI*60 #To make it end instantly while ignoring ISI
             while self.dispMovieStim(1, dMovie) < 2:
@@ -486,8 +487,8 @@ class PyHab:
         """
 
         if self.frameCount == 0:  # initial setup
-            dispMovie.draw()
             self.frameCount += 1
+            dispMovie.draw()
             if trialType == 0:
                 self.frameCount = 0  # for post-attn-getter pause
                 dispMovie.pause()
@@ -513,7 +514,8 @@ class PyHab:
             self.pauseCount = 0
             dispMovie.draw()  # Comment this out as well to blank between loops.
             self.win.flip()
-            dispMovie.seek(0.0)
+            dispMovie.pause()
+            #dispMovie.seek(0.0) #This seek seems to cause the replays.
             return 2
         else:
             dispMovie.draw()
@@ -596,6 +598,7 @@ class PyHab:
     def redoSetup(self, tn, autoAdv):
         """
         Lays the groundwork for redoTrial, including correcting the trial order, selecting the right stim, etc.
+
         :param tn: Trial number (trialNum)
         :type tn: int
         :param autoAdv: The current auto-advance trial type list (different on first trial for Reasons)
@@ -628,7 +631,7 @@ class PyHab:
                     self.stimName = self.stimNames[trialType][self.counters[trialType]]
                 disMovie = self.stimDict[trialType][self.counters[trialType]]
                 self.counters[trialType] += 1
-                if self.counters[trialType] >= len(self.stimDict[trialType]):
+                if self.counters[trialType] < 0:
                     self.counters[trialType] = 0
             else:
                 disMovie = 0
@@ -740,7 +743,7 @@ class PyHab:
                 self.stimDict['Hab'].insert(self.habCount, tempAdd)
             disMovie = self.stimDict[trialType][self.counters[trialType]]
             self.counters[trialType] += 1
-            if self.counters[trialType] >= len(self.stimDict[trialType]):
+            if self.counters[trialType] < 0:
                 self.counters[trialType] = 0
         else:
             disMovie = 0
@@ -791,14 +794,19 @@ class PyHab:
                 if self.keyboard[self.key.Y]:
                     end = True
                 elif self.keyboard[self.key.R] and not didRedo:
+                    if self.counters[trialType] > 0:
+                        self.counters[trialType] -= 1
                     [disMovie,trialNum] = self.redoSetup(trialNum, AA) #This returns a new value for DisMovie and trialNum
+                    if disMovie['stimType'] == 'Movie':
+                        disMovie['stim'].pause() # Anything to try to get it to stop double-playing
+                        disMovie['stim'].seek(0.0)
+                        disMovie['stim'].pause()
                     trialType = self.actualTrialOrder[trialNum - 1]
                     didRedo = True
                 elif self.keyboard[self.key.J] and 'Hab' in self.actualTrialOrder[trialNum:]:  # jump to test in a hab design
                     [disMovie, trialType] = self.jumpToTest(trialNum)
                 elif trialType != 'Hab' and self.keyboard[self.key.I] and 'Hab' in self.trialOrder and trialType not in self.habTrialList:  # insert additional hab trial
                     [disMovie, trialType] = self.insertHab(trialNum)
-
                 elif trialNum > 1 and not self.stimPres and self.keyboard[self.key.P] and not reviewed:  # Print data so far, as xHab. Non-stimulus version only. Only between trials.
                     reviewed = True
                     print("hab crit, on-timeA, numOnA, offtimeA, numOffA, onTimeB, numOnB, offTimeB, numOffB")
@@ -855,7 +863,12 @@ class PyHab:
                         waitStart = False
                         self.dispCoderWindow(trialType)
                     elif self.keyboard[self.key.R] and not didRedo:  # Redo last trial, mark last trial as bad
+                        if self.counters[trialType] > 0:
+                            self.counters[trialtype] -= 1
                         [disMovie, trialNum] = self.redoSetup(trialNum, AA)  # This returns a new value for DisMovie and trialNum
+                        if disMovie['stimType'] == 'Movie':
+                            disMovie['stim'].seek(0.0)
+                            disMovie['stim'].pause()
                         trialType = self.actualTrialOrder[trialNum - 1]
                         didRedo = True
                     elif self.keyboard[self.key.J] and trialType == 'Hab':  # jump to test in a hab design
@@ -937,6 +950,7 @@ class PyHab:
         # returns 0 if do next trial, 1 if end hab, 2 if end experiment, 3 if abort/redo
         if self.stimPres and disMovie['stimType'] == 'Movie':
             disMovie['stim'].seek(0.0)
+            disMovie['stim'].pause()
         startTrial = core.getTime()
         startTrial2 = core.getTime()
         onArray = []
@@ -1111,7 +1125,6 @@ class PyHab:
         if self.stimPres:
             # Reset everything, stop playing sounds and movies.
             if disMovie['stimType'] == 'Movie':
-                disMovie['stim'].seek(0.0)  # this is the reset, we hope.
                 disMovie['stim'].pause()
             elif disMovie['stimType'] == 'Audio':
                 disMovie['stim'].stop()
@@ -1121,6 +1134,9 @@ class PyHab:
             if self.actualTrialOrder[number] not in self.autoAdvance:
                 self.win.flip()  # blanks the screen outright between trials if NOT auto-advancing into the next trial
         if redo:  # if the abort button was pressed
+            if self.stimPres and disMovie['stimType'] == 'Movie':
+                disMovie['stim'].seek(0.0)
+                disMovie['stim'].pause()
             self.abortTrial(onArray, offArray, number, type, onArray2, offArray2, self.stimName)
             return 3
         else:

--- a/PyHab/PyHabClass.py
+++ b/PyHab/PyHabClass.py
@@ -798,9 +798,7 @@ class PyHab:
                         self.counters[trialType] -= 1
                     [disMovie,trialNum] = self.redoSetup(trialNum, AA) #This returns a new value for DisMovie and trialNum
                     if disMovie['stimType'] == 'Movie':
-                        disMovie['stim'].pause() # Anything to try to get it to stop double-playing
-                        disMovie['stim'].seek(0.0)
-                        disMovie['stim'].pause()
+                        disMovie['stim'].loadMovie(disMovie['stim'].filename) # "Seek" causes audio bugs. This just reloads the movie. More memory load, but reliable.
                     trialType = self.actualTrialOrder[trialNum - 1]
                     didRedo = True
                 elif self.keyboard[self.key.J] and 'Hab' in self.actualTrialOrder[trialNum:]:  # jump to test in a hab design
@@ -867,8 +865,7 @@ class PyHab:
                             self.counters[trialtype] -= 1
                         [disMovie, trialNum] = self.redoSetup(trialNum, AA)  # This returns a new value for DisMovie and trialNum
                         if disMovie['stimType'] == 'Movie':
-                            disMovie['stim'].seek(0.0)
-                            disMovie['stim'].pause()
+                            disMovie['stim'].loadMovie(disMovie['stim'].filename)
                         trialType = self.actualTrialOrder[trialNum - 1]
                         didRedo = True
                     elif self.keyboard[self.key.J] and trialType == 'Hab':  # jump to test in a hab design

--- a/PyHab/PyHabClassPL.py
+++ b/PyHab/PyHabClassPL.py
@@ -499,11 +499,11 @@ class PyHabPL(PyHab):
             o += 1
             nDupe = str(o)
             filename = self.dataFolder + self.prefix + str(self.sNum) + '_' + str(self.sID) + nDupe + '_' + str(self.today.month) + str(self.today.day) + str(self.today.year) + '.csv'
-        outputWriter = csv.DictWriter(open(filename,'w'),
-                                      fieldnames = self.dataColumns, extrasaction='ignore', lineterminator ='\n') #careful! this OVERWRITES the existing file. Fills from snum.
-        outputWriter.writeheader()
-        for r in range(0, len(self.dataMatrix)):
-            outputWriter.writerow(self.dataMatrix[r])
+        with open(filename, 'w') as f:
+            outputWriter = csv.DictWriter(f,fieldnames = self.dataColumns, extrasaction='ignore', lineterminator ='\n')
+            outputWriter.writeheader()
+            for r in range(0, len(self.dataMatrix)):
+                outputWriter.writerow(self.dataMatrix[r])
         #Now to construct and save verbose data
         verboseMatrix = []
         #first, verbose data is not as well organized. However, we should be able to alternate back and forth between
@@ -600,11 +600,11 @@ class PyHabPL(PyHab):
                     verboseMatrix.extend(trialVerbose2)
         headers2 = ['snum', 'months', 'days', 'sex', 'cond', 'GNG', 'gazeOnOff', 'trial', 'trialType',
                                 'startTime', 'endTime', 'duration']
-        outputWriter2 = csv.DictWriter(open(self.dataFolder+self.prefix+str(self.sNum)+'_'+str(self.sID)+nDupe+'_'+str(self.today.month)+str(self.today.day)+str(self.today.year)+'_VERBOSE.csv','w'),
-                                       fieldnames = headers2, extrasaction = 'ignore', lineterminator ='\n') #careful! this OVERWRITES the existing file. Fills from snum.
-        outputWriter2.writeheader()
-        for z in range(0,len(verboseMatrix)):
-            outputWriter2.writerow(verboseMatrix[z])
+        with open(self.dataFolder+self.prefix+str(self.sNum)+'_'+str(self.sID)+nDupe+'_'+str(self.today.month)+str(self.today.day)+str(self.today.year)+'_VERBOSE.csv','w') as f:
+            outputWriter2 = csv.DictWriter(f, fieldnames = headers2, extrasaction = 'ignore', lineterminator ='\n') #careful! this OVERWRITES the existing file. Fills from snum.
+            outputWriter2.writeheader()
+            for z in range(0,len(verboseMatrix)):
+                outputWriter2.writerow(verboseMatrix[z])
         core.wait(.3)
         self.win2.close()
         if self.stimPres:


### PR DESCRIPTION
Fixes four big bugs:

Audio doubling: Removed a lot of redundant "seek" commands. Audio doubling and phantom audio playing should now be much less common.

Redo movie selection with auto-advance: Fixed an edge case that led to incorrect stimulus selection in very specific cases when redoing an auto-advancing set of trials.

Windows/Mac transfer compatibility: Fixed a set of issued moving experiments between Windows and Mac.

Windows save behavior: Changed how data are saved so that saving is faster and much more reliable on Windows.