### PR TITLE
0.6.3

### DIFF
--- a/PyHab/PyHabBuilder.py
+++ b/PyHab/PyHabBuilder.py
@@ -132,6 +132,10 @@ class PyHabBuilder:
                 if i in ['stimList','attnGetterList']:
                     for [i,j] in self.settings[i].items():
                         j['stimLoc'] = ''.join([self.dirMarker if x == otherOS else x for x in j['stimLoc']])
+            # Backwards compatibility for startImage and endImage
+            if 'startImage' not in self.settings.keys():
+                self.settings['startImage'] = ''
+                self.settings['endImage'] = ''
             self.settings['dataloc'] = ''.join([self.dirMarker if x == otherOS else x for x in self.settings['dataloc']])
             self.settings['stimPath'] = ''.join([self.dirMarker if x == otherOS else x for x in self.settings['stimPath']])
             self.trialTypesArray = self.loadTypes()

--- a/PyHab/PyHabBuilder.py
+++ b/PyHab/PyHabBuilder.py
@@ -18,6 +18,7 @@ class PyHabBuilder:
     with different trial types.
 
     TODO: Add the ability to remove stimuli once added. Nonessential.
+    TODO: Major crashes when adding a new trial type to something with existing condition settings! Need to make it so it prompts user
     """
     def __init__(self, loadedSaved=False, settingsDict={}):
         """

--- a/PyHab/PyHabBuilder.py
+++ b/PyHab/PyHabBuilder.py
@@ -18,7 +18,6 @@ class PyHabBuilder:
     with different trial types.
 
     TODO: Add the ability to remove stimuli once added. Nonessential.
-
     """
     def __init__(self, loadedSaved=False, settingsDict={}):
         """
@@ -78,8 +77,8 @@ class PyHabBuilder:
             self.settings = {'dataColumns': ['sNum', 'months', 'days', 'sex', 'cond','condLabel', 'trial','GNG','trialType','stimName','habCrit','sumOnA','numOnA','sumOffA','numOffA','sumOnB','numOnB','sumOffB','numOffB'],
                                                         'prefix': 'PyHabExperiment',
                                                         'dataloc':'data'+self.dirMarker,
-                                                        'maxDur': { }, 
-                                                        'playThrough': { },
+                                                        'maxDur': {},
+                                                        'playThrough': {},
                                                         'movieEnd': [],
                                                         'maxOff': {},
                                                         'minOn': {},
@@ -119,7 +118,9 @@ class PyHabBuilder:
                                                                                           'color':'yellow'}},
                                                         'folderPath':'',
                                                         'trialTypes':[],
-                                                        'prefLook':'0'}
+                                                        'prefLook':'0',
+                                                        'startImage':'',
+                                                        'endImage':''}
             self.studyFlowArray={'lines':[],'shapes':[],'text':[],'labels':[]} # an array of objects for the study flow.
             self.trialTypesArray={'shapes':[],'text':[],'labels':[]}
         else:
@@ -1150,7 +1151,8 @@ class PyHabBuilder:
     def addStimToTypesDlg(self):
         """
         A series dialog boxes, the first selecting a trial type and the number of stimuli to add to it,
-        a second allowing you to add stimuli from the stimulus library that is stimList in the settings
+        a second allowing you to add stimuli from the stimulus library that is stimList in the settings.
+        Also used for adding beginning and end of experiment images (?)
 
         :return:
         :rtype:
@@ -1162,7 +1164,10 @@ class PyHabBuilder:
 
         if len(self.trialTypesArray['labels']) > 0:
             d1 = gui.Dlg(title="Select trial type to add stimuli to")
-            d1.addField("Trial type to add stimulus file to", choices=self.trialTypesArray['labels'])
+            choiceList=['Start and end of experiment screens']
+            for i in range(0, len(self.trialTypesArray['labels'])): # Not just copying list b/c it would add start/end to it
+                choiceList.append(self.trialTypesArray['labels'][i])
+            d1.addField("Trial type to add stimulus file to", choices=choiceList)
             d1.addField("Number of stimuli to add (you will select them in the next window)",1)
             d1.addText("Note: You can only select stimuli you have already added to the experiment library")
             d1.addText("Note: You can only REMOVE stimuli from a trial type in the trial type's own settings, this will add to whatever is already there")
@@ -1174,15 +1179,44 @@ class PyHabBuilder:
                 self.win.flip()
                 tType = d[0]
                 numAdd = d[1]
-                d2 = gui.Dlg(title="Select stimuli")
-                stimKeyList = list(self.settings['stimList'].keys())
-                stimKeyList.sort()
-                for i in range(0, numAdd):
-                    d2.addField("Stimulus no. " + str(i+1), choices=stimKeyList)
-                newList = d2.show()
-                if d2.OK:
-                    for z in range(0, len(newList)):
-                        self.settings['stimNames'][tType].append(newList[z])
+                if tType != 'Start and end of experiment screens':
+                    d2 = gui.Dlg(title="Select stimuli")
+                    stimKeyList = list(self.settings['stimList'].keys())
+                    stimKeyList.sort()
+                    for i in range(0, numAdd):
+                        d2.addField("Stimulus no. " + str(i+1), choices=stimKeyList)
+                    newList = d2.show()
+                    if d2.OK:
+                        for z in range(0, len(newList)):
+                            self.settings['stimNames'][tType].append(newList[z])
+                else:
+                    d2 = gui.Dlg(title="Select image")
+                    # Create a list of just image stim
+                    startimgs = [x for x in list(self.settings['stimList'].keys()) if self.settings['stimList'][x]['stimType'] == 'Image']
+                    startimgs.sort()
+                    startimgs.insert(0,'None')
+                    if self.settings['startImage'] != '':
+                        startimgs = [x for x in startimgs if x != self.settings['startImage']]
+                        startimgs.insert(0,self.settings['startImage'])
+                    endimgs = [x for x in list(self.settings['stimList'].keys()) if self.settings['stimList'][x]['stimType'] == 'Image']
+                    endimgs.sort()
+                    endimgs.insert(0,'None')
+                    if self.settings['endImage'] != '':
+                        endimgs = [x for x in endimgs if x != self.settings['endImage']]
+                        endimgs.insert(0, self.settings['endImage'])
+                    d2.addField("Start of experiment image", choices=startimgs)
+                    d2.addField("End of experiment image", choices=endimgs)
+
+                    newList = d2.show()
+                    if d2.OK:
+                        if newList[0] is not 'None':
+                            self.settings['startImage'] = newList[0]
+                        else:
+                            self.settings['startImage'] = ''
+                        if newList[1] is not 'None':
+                            self.settings['endImage'] = newList[1]
+                        else:
+                            self.settings['endImage'] = ''
 
         else:
             errDlg = gui.Dlg(title="No trial types!")

--- a/PyHab/PyHabBuilder.py
+++ b/PyHab/PyHabBuilder.py
@@ -1164,9 +1164,10 @@ class PyHabBuilder:
 
         if len(self.trialTypesArray['labels']) > 0:
             d1 = gui.Dlg(title="Select trial type to add stimuli to")
-            choiceList=['Start and end of experiment screens']
+            choiceList=[]
             for i in range(0, len(self.trialTypesArray['labels'])): # Not just copying list b/c it would add start/end to it
                 choiceList.append(self.trialTypesArray['labels'][i])
+            choiceList.append('Start and end of experiment screens')
             d1.addField("Trial type to add stimulus file to", choices=choiceList)
             d1.addField("Number of stimuli to add (you will select them in the next window)",1)
             d1.addText("Note: You can only select stimuli you have already added to the experiment library")

--- a/PyHab/PyHabClass.py
+++ b/PyHab/PyHabClass.py
@@ -117,9 +117,11 @@ class PyHab:
         try: # To allow for better backwards compatibility, won't crash if this was made in a version that has no startImage or endImage lines
             self.startImage = settingsDict['startImage']
             self.endImage = settingsDict['endImage']
+            self.nextFlash = eval(settingsDict['nextFlash']) # 0 or 1, whether to flash when A is required for next trial.
         except:
             self.startImage = ''
             self.endImage = ''
+            self.nextFlash = 0
 
         if len(self.stimPath) > 0 and self.stimPath[-1] is not self.dirMarker:  # If it was made in one OS and running in another
             self.stimPath = [self.dirMarker if x == otherOS else x for x in self.stimPath]
@@ -426,6 +428,37 @@ class PyHab:
 
         self.dispCoderWindow(0)
         #self.win.flip()  # clear screen (change?)
+
+    def flashCoderWindow(self, rep=False):
+        """
+        Flash the background of the coder window to alert the experimenter they need to initiate the next trial.
+        .2 seconds of white and black, flashed twice. Can lengthen gap between trial but listens for 'A' on every flip.
+
+        :return:
+        :rtype:
+        """
+        flashing = True
+
+        # at 60fps, 200ms = 12 frames.
+        for i in range(0,12):
+            self.win2.color='white'
+            self.dispCoderWindow()
+            if self.keyboard[self.key.A]:
+                flashing = False
+                break
+        if flashing:
+            for i in range(0,12):
+                self.win2.color='black'
+                self.dispCoderWindow()
+                if self.keyboard[self.key.A]:
+                    flashing = False
+                    break
+            if flashing and not rep:
+                self.flashCoderWindow(rep=True)
+        self.win2.color='black'
+
+
+
 
     def dispCoderWindow(self, trialType = -1):
         """
@@ -796,6 +829,8 @@ class PyHab:
             if self.blindPres < 1:
                 self.rdyTextAppend = " NEXT: " + self.actualTrialOrder[trialNum - 1] + " TRIAL"
             end = False
+            if trialType not in AA and self.nextFlash in [1,'1',True,'True']: # The 'flasher' to alert the experimenter they need to start the next trial
+                self.flashCoderWindow()
             while not self.keyboard[self.key.A] and trialType not in AA and not end:  # wait for 'ready' key, check at frame intervals
                 if self.keyboard[self.key.Y]:
                     end = True

--- a/PyHab/PyHabClassPL.py
+++ b/PyHab/PyHabClassPL.py
@@ -483,6 +483,14 @@ class PyHabPL(PyHab):
         :return:
         :rtype:
         """
+        tempText = visual.TextStim(self.win2, text="Saving data...", pos=[0, 0], color='white', bold=True, height=40)
+        tempText.draw()
+        self.win2.flip()
+        if self.stimPres:
+            if self.endImageObject is not None:
+                self.endImageObject.draw()
+            self.win.flip()
+
         #sort the data matrices and shuffle them together.
         if len(self.badTrials) > 0: #if there are any redos, they need to be shuffled in appropriately.
             for i in range(0,len(self.badTrials)):
@@ -605,7 +613,19 @@ class PyHabPL(PyHab):
             outputWriter2.writeheader()
             for z in range(0,len(verboseMatrix)):
                 outputWriter2.writerow(verboseMatrix[z])
-        core.wait(.3)
+        # core.wait(.3) Replaced by end-of-experiment screen
+        # "end of experiment" screen. By default this will go to a black screen on the stim view
+        # and display "Experiment finished!" on the experimenter view
+        tempText.text = "Experiment finished! Press return to close."
+        tempText.height = 18
+        tempText.draw()
+        self.win2.flip()
+        if self.stimPres:
+            if self.endImageObject is not None:
+                self.endImageObject.draw()
+            self.win.flip()
+        event.waitKeys(keyList='return')
+
         self.win2.close()
         if self.stimPres:
             self.win.close()

--- a/PyHabDemo/PyHab/PyHabBuilder.py
+++ b/PyHabDemo/PyHab/PyHabBuilder.py
@@ -18,6 +18,7 @@ class PyHabBuilder:
     with different trial types.
 
     TODO: Add the ability to remove stimuli once added. Nonessential.
+    TODO: Start and end images
 
     """
     def __init__(self, loadedSaved=False, settingsDict={}):
@@ -32,8 +33,10 @@ class PyHabBuilder:
         self.loadSave = loadedSaved #For easy reference elsewhere
         if os.name is 'posix': #glorious simplicity of unix filesystem
             self.dirMarker = '/'
+            otherOS = '\\'
         elif os.name is 'nt': #Nonsensical Windows-based contrarianism
-            self.dirMarker='\\'
+            self.dirMarker = '\\'
+            otherOS = '/'
         #The base window
         width = 1080
         height = 600
@@ -76,8 +79,8 @@ class PyHabBuilder:
             self.settings = {'dataColumns': ['sNum', 'months', 'days', 'sex', 'cond','condLabel', 'trial','GNG','trialType','stimName','habCrit','sumOnA','numOnA','sumOffA','numOffA','sumOnB','numOnB','sumOffB','numOffB'],
                                                         'prefix': 'PyHabExperiment',
                                                         'dataloc':'data'+self.dirMarker,
-                                                        'maxDur': { }, 
-                                                        'playThrough': { },
+                                                        'maxDur': {},
+                                                        'playThrough': {},
                                                         'movieEnd': [],
                                                         'maxOff': {},
                                                         'minOn': {},
@@ -117,7 +120,9 @@ class PyHabBuilder:
                                                                                           'color':'yellow'}},
                                                         'folderPath':'',
                                                         'trialTypes':[],
-                                                        'prefLook':'0'}
+                                                        'prefLook':'0',
+                                                        'startImage':'',
+                                                        'endImage':''}
             self.studyFlowArray={'lines':[],'shapes':[],'text':[],'labels':[]} # an array of objects for the study flow.
             self.trialTypesArray={'shapes':[],'text':[],'labels':[]}
         else:
@@ -126,6 +131,11 @@ class PyHabBuilder:
                         'maxOff','minOn','autoAdvance','playAttnGetter','attnGetterList','trialTypes','habTrialList']
             for i in evalList:
                 self.settings[i] = eval(self.settings[i])
+                if i in ['stimList','attnGetterList']:
+                    for [i,j] in self.settings[i].items():
+                        j['stimLoc'] = ''.join([self.dirMarker if x == otherOS else x for x in j['stimLoc']])
+            self.settings['dataloc'] = ''.join([self.dirMarker if x == otherOS else x for x in self.settings['dataloc']])
+            self.settings['stimPath'] = ''.join([self.dirMarker if x == otherOS else x for x in self.settings['stimPath']])
             self.trialTypesArray = self.loadTypes()
             self.studyFlowArray = self.loadFlow()
             # Get conditions!
@@ -1143,7 +1153,8 @@ class PyHabBuilder:
     def addStimToTypesDlg(self):
         """
         A series dialog boxes, the first selecting a trial type and the number of stimuli to add to it,
-        a second allowing you to add stimuli from the stimulus library that is stimList in the settings
+        a second allowing you to add stimuli from the stimulus library that is stimList in the settings.
+        Also used for adding beginning and end of experiment images (?)
 
         :return:
         :rtype:
@@ -1155,7 +1166,10 @@ class PyHabBuilder:
 
         if len(self.trialTypesArray['labels']) > 0:
             d1 = gui.Dlg(title="Select trial type to add stimuli to")
-            d1.addField("Trial type to add stimulus file to", choices=self.trialTypesArray['labels'])
+            choiceList=['Start and end of experiment screens']
+            for i in range(0, len(self.trialTypesArray['labels'])): # Not just copying list b/c it would add start/end to it
+                choiceList.append(self.trialTypesArray['labels'][i])
+            d1.addField("Trial type to add stimulus file to", choices=choiceList)
             d1.addField("Number of stimuli to add (you will select them in the next window)",1)
             d1.addText("Note: You can only select stimuli you have already added to the experiment library")
             d1.addText("Note: You can only REMOVE stimuli from a trial type in the trial type's own settings, this will add to whatever is already there")
@@ -1167,15 +1181,44 @@ class PyHabBuilder:
                 self.win.flip()
                 tType = d[0]
                 numAdd = d[1]
-                d2 = gui.Dlg(title="Select stimuli")
-                stimKeyList = list(self.settings['stimList'].keys())
-                stimKeyList.sort()
-                for i in range(0, numAdd):
-                    d2.addField("Stimulus no. " + str(i+1), choices=stimKeyList)
-                newList = d2.show()
-                if d2.OK:
-                    for z in range(0, len(newList)):
-                        self.settings['stimNames'][tType].append(newList[z])
+                if tType != 'Start and end of experiment screens':
+                    d2 = gui.Dlg(title="Select stimuli")
+                    stimKeyList = list(self.settings['stimList'].keys())
+                    stimKeyList.sort()
+                    for i in range(0, numAdd):
+                        d2.addField("Stimulus no. " + str(i+1), choices=stimKeyList)
+                    newList = d2.show()
+                    if d2.OK:
+                        for z in range(0, len(newList)):
+                            self.settings['stimNames'][tType].append(newList[z])
+                else:
+                    d2 = gui.Dlg(title="Select image")
+                    # Create a list of just image stim
+                    startimgs = [x for x in list(self.settings['stimList'].keys()) if self.settings['stimList'][x]['stimType'] == 'Image']
+                    startimgs.sort()
+                    startimgs.insert(0,'None')
+                    if self.settings['startImage'] != '':
+                        startimgs = [x for x in startimgs if x != self.settings['startImage']]
+                        startimgs.insert(0,self.settings['startImage'])
+                    endimgs = [x for x in list(self.settings['stimList'].keys()) if self.settings['stimList'][x]['stimType'] == 'Image']
+                    endimgs.sort()
+                    endimgs.insert(0,'None')
+                    if self.settings['endImage'] != '':
+                        endimgs = [x for x in endimgs if x != self.settings['endImage']]
+                        endimgs.insert(0, self.settings['endImage'])
+                    d2.addField("Start of experiment image", choices=startimgs)
+                    d2.addField("End of experiment image", choices=endimgs)
+
+                    newList = d2.show()
+                    if d2.OK:
+                        if newList[0] is not 'None':
+                            self.settings['startImage'] = newList[0]
+                        else:
+                            self.settings['startImage'] = ''
+                        if newList[1] is not 'None':
+                            self.settings['endImage'] = newList[1]
+                        else:
+                            self.settings['endImage'] = ''
 
         else:
             errDlg = gui.Dlg(title="No trial types!")
@@ -1771,16 +1814,16 @@ class PyHabBuilder:
         if not os.path.exists(codePath):
             os.makedirs(codePath)
         srcDir = 'PyHab'+self.dirMarker
-        # Condition file!
+        # Condition file! Save if there are any conditions created.
+        # Convoluted mess because the dict won't necessarily be in order and we want the file to be.
         if len(self.condDict)>0:
             tempArray = []
             for j in range(0, len(self.settings['condList'])):
                 tempArray.append([self.settings['condList'][j],self.condDict[self.settings['condList'][j]]])
-            co = open(self.folderPath+self.settings['condFile'],'wb')
-            secretWriter = csv.writer(co)
-            for k in range(0, len(tempArray)):
-                secretWriter.writerow(tempArray[k])
-            co.close()
+            with open(self.folderPath+self.settings['condFile'],'w') as co:
+                secretWriter = csv.writer(co,lineterminator='\n')
+                for k in range(0, len(tempArray)):
+                    secretWriter.writerow(tempArray[k])
         # copy stimuli if there are stimuli.
         if len(self.stimSource) > 0:
             for i, j in self.stimSource.items():  # Find each file, copy it over
@@ -1818,13 +1861,12 @@ class PyHabBuilder:
             errDlg.show()
         # create/overwrite the settings csv.
         settingsPath = self.folderPath+self.settings['prefix']+'Settings.csv'
-        so = open(settingsPath,'w')
-        settingsOutput = csv.writer(so, lineterminator='\n')
-        for i, j in self.settings.items():#this is how you write key/value pairs
-            settingsOutput.writerow([i, j])
-        # close the settings file, to allow it to be read immediately (in theory)
-        so.close()
-        # Copy over the class and such. Since these aren't modiied, make sure they don't exist first.
+        with open(settingsPath,'w') as so: # this is theoretically safer than the "close" system.
+            settingsOutput = csv.writer(so, lineterminator='\n')
+            for i, j in self.settings.items(): # this is how you write key/value pairs
+                settingsOutput.writerow([i, j])
+
+        # Copy over the class and such. Since these aren't modified, make sure they don't exist first.
         classPath = 'PyHabClass.py'
         classTarg = codePath+classPath
         classPLPath = 'PyHabClassPL.py'

--- a/PyHabDemo/PyHab/PyHabBuilder.py
+++ b/PyHabDemo/PyHab/PyHabBuilder.py
@@ -18,8 +18,6 @@ class PyHabBuilder:
     with different trial types.
 
     TODO: Add the ability to remove stimuli once added. Nonessential.
-    TODO: Start and end images
-
     """
     def __init__(self, loadedSaved=False, settingsDict={}):
         """
@@ -122,18 +120,25 @@ class PyHabBuilder:
                                                         'trialTypes':[],
                                                         'prefLook':'0',
                                                         'startImage':'',
-                                                        'endImage':''}
+                                                        'endImage':'',
+                                                        'nextFlash':'0'}
             self.studyFlowArray={'lines':[],'shapes':[],'text':[],'labels':[]} # an array of objects for the study flow.
             self.trialTypesArray={'shapes':[],'text':[],'labels':[]}
         else:
             self.settings = settingsDict
+            if 'nextFlash' not in self.settings.keys():
+                self.settings['nextFlash'] = '0'
             evalList = ['dataColumns','maxDur','condList','movieEnd','playThrough','trialOrder','stimNames', 'stimList',
-                        'maxOff','minOn','autoAdvance','playAttnGetter','attnGetterList','trialTypes','habTrialList']
+                        'maxOff','minOn','autoAdvance','playAttnGetter','attnGetterList','trialTypes','habTrialList','nextFlash']
             for i in evalList:
                 self.settings[i] = eval(self.settings[i])
                 if i in ['stimList','attnGetterList']:
                     for [i,j] in self.settings[i].items():
                         j['stimLoc'] = ''.join([self.dirMarker if x == otherOS else x for x in j['stimLoc']])
+            # Backwards compatibility for startImage and endImage
+            if 'startImage' not in self.settings.keys():
+                self.settings['startImage'] = ''
+                self.settings['endImage'] = ''
             self.settings['dataloc'] = ''.join([self.dirMarker if x == otherOS else x for x in self.settings['dataloc']])
             self.settings['stimPath'] = ''.join([self.dirMarker if x == otherOS else x for x in self.settings['stimPath']])
             self.trialTypesArray = self.loadTypes()
@@ -551,6 +556,11 @@ class PyHabBuilder:
                         self.trialTypesArray['text'].append(tempTxt)
                         self.settings['trialTypes'].append(typeInfo[0])
                         self.settings['stimNames'][typeInfo[0]] = []
+                        # If there exists a condition file or condition settings, warn the user that they will need to be updated!
+                        if self.settings['condFile'] is not '':
+                            warnDlg = gui.Dlg(title="Update conditions")
+                            warnDlg.addText("WARNING! UPDATE CONDITION SETTINGS AFTER ADDING STIMULI TO THIS TRIAL TYPE! \nIf you do not update conditions, the experiment will crash whenever it reaches this trial type.")
+                            warnDlg.show()
                 self.studyFlowArray = self.loadFlow()
                 self.showMainUI()
                 self.win.flip()
@@ -950,6 +960,9 @@ class PyHabBuilder:
 
         3 = prefLook: Whether the study is preferential-looking or single-target.
 
+        4 = nextFlash: Whether to have the coder window flash to alert the experimenter they need to manually trigger
+            the next trial
+
         :return:
         :rtype:
         """
@@ -975,6 +988,11 @@ class PyHabBuilder:
         else:
             ch2=["Single-target", "Preferential looking"]
         uDlg.addField("Single-target or preferential looking?",choices=ch2)
+        if self.settings['nextFlash'] in ['1',1,'True',True]:
+            ch3 = ["Yes","No"]
+        else:
+            ch3= ["No","Yes"]
+        uDlg.addField("Flash to alert experimenter to manually start next trial?", choices=ch3)
         uInfo = uDlg.show()
         if uDlg.OK:
             self.settings['prefix'] = uInfo[0]
@@ -991,6 +1009,10 @@ class PyHabBuilder:
             elif uInfo[3] == "Single-target" and self.settings['prefLook'] in [1,'1','True',True]:
                 self.settings['prefLook'] = 0
                 self.settings['dataColumns'] = self.allDataColumns
+            if uInfo[4] == "Yes":
+                self.settings['nextFlash'] = 1
+            else:
+                self.settings['nextFlash'] = 0
         
     def dataSettingsDlg(self):
         """
@@ -1166,9 +1188,10 @@ class PyHabBuilder:
 
         if len(self.trialTypesArray['labels']) > 0:
             d1 = gui.Dlg(title="Select trial type to add stimuli to")
-            choiceList=['Start and end of experiment screens']
+            choiceList=[]
             for i in range(0, len(self.trialTypesArray['labels'])): # Not just copying list b/c it would add start/end to it
                 choiceList.append(self.trialTypesArray['labels'][i])
+            choiceList.append('Start and end of experiment screens')
             d1.addField("Trial type to add stimulus file to", choices=choiceList)
             d1.addField("Number of stimuli to add (you will select them in the next window)",1)
             d1.addText("Note: You can only select stimuli you have already added to the experiment library")


### PR DESCRIPTION
Adds some new features:

- Allows for the addition of an image to put on the screen before the experiment starts, and one to put at the end, along with a change to the flow such that the stimulus screen stays blank or shows the end image until the experiment tells it to close, better supporting, e.g., a post-presentation choice phase

- This new feature is fully backwards-compatible. Experiments built in older versions of 0.6 will still work with the new version.

- Added the option to make the coder window flash when experimenter input is required to start the next trial (i.e., when it is not auto-advancing into the next trial).

- Added a warning message when creating new trial types after a condition file has been created. Adding new trial types without updating the condition file leads to crashes.

- The manual has been updated and improved.